### PR TITLE
Fix console errors and warnings

### DIFF
--- a/src/common/LoadingScreen/LoadingScreen.tsx
+++ b/src/common/LoadingScreen/LoadingScreen.tsx
@@ -1,17 +1,20 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import './LoadingScreen.scss';
 import { LoadingOutlined } from '@ant-design/icons';
 import { Spin } from 'antd';
 
 export const LoadingScreen: React.FC<any> = props => {
     const [loading, setLoading] = useState(false);
-    setTimeout(() => {
-        setLoading(true);
-    }, 1000);
+
+    useEffect(() => {
+        setTimeout(() => {
+            setLoading(true);
+        }, 1000);
+    }, [])
 
     return (<div className="loading-container">
         <div className="wrapper">
-            <img src={require('../../assets/loading.png').default} alt="Logo" /> 
+            <img src={require('../../assets/loading.png').default} alt="Logo" />
             {loading && <Spin className="spinner" indicator={<LoadingOutlined style={{ fontSize: 24 }} spin />} />}
         </div>
     </div>);

--- a/src/main-layout/SessionWindow/MessageDiffViewerTab/MessageDiffViewerManagement/MessageDiffViewerManagement.tsx
+++ b/src/main-layout/SessionWindow/MessageDiffViewerTab/MessageDiffViewerManagement/MessageDiffViewerManagement.tsx
@@ -150,8 +150,8 @@ export class MessageDiffViewerManagement extends React.Component<any, MessageDif
                             const prof = GlobalServiceRegistry.profile.getProfile(inst);
                             this.onNewSession(prof!.dictionaryLocation, prof?.fixVersion, prof?.transportDictionaryLocation);
                         }}>
-                            {GlobalServiceRegistry.profile.getAllProfiles().map(inst => {
-                                return <Option value={inst.name} >{inst.name}</Option>
+                            {GlobalServiceRegistry.profile.getAllProfiles().map((inst, i) => {
+                                return <Option value={inst.name} key={i}>{inst.name}</Option>
                             })}
                         </Select>
                     </Form.Item>

--- a/src/main-layout/SessionWindow/MessageViewerTab/MessageViewerManagement/MessageViewerManagement.tsx
+++ b/src/main-layout/SessionWindow/MessageViewerTab/MessageViewerManagement/MessageViewerManagement.tsx
@@ -85,8 +85,8 @@ export class MessageViewerManagement extends React.Component<any, MessageViewerM
                             const prof = GlobalServiceRegistry.profile.getProfile(inst);
                             this.onNewSession(prof!.dictionaryLocation, prof?.fixVersion, prof?.transportDictionaryLocation);
                         }}>
-                            {GlobalServiceRegistry.profile.getAllProfiles().map(inst => {
-                                return <Option value={inst.name} >{inst.name}</Option>
+                            {GlobalServiceRegistry.profile.getAllProfiles().map((inst, i) => {
+                                return <Option value={inst.name} key={i}>{inst.name}</Option>
                             })}
                         </Select>
                     </Form.Item>

--- a/src/translations/languages/en.json
+++ b/src/translations/languages/en.json
@@ -223,7 +223,7 @@
 		"msg_invalid_message_title": "Invalid Message",
 		"raw_msg_1": "Expected Message",
 		"raw_msg_2": "Received Message",
-		"raw_msg_desc": "You can compare two messages using this window. The expected message supports regular expressions (Javascript Type) for the fields and you can define a regular expression using ${<reg exp>} notation. Please note that the field separator should be defined as a printable character instead of the SOH character.",
+		"raw_msg_desc": "You can compare two messages using this window. The expected message supports regular expressions (Javascript Type) for the fields and you can define a regular expression using $'{<reg exp>} notation. Please note that the field separator should be defined as a printable character instead of the SOH character.",
 		"field_separator": "Field Separator",
 		"view": "Compare",
 		"fix_definition": "Fix definition",


### PR DESCRIPTION
An attempt to fix following console errors and warnings

> Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function. at LoadingScreen

> react-intl-universal format message failed for key='message_diff_viewer.raw_msg_desc'. Expected argNameOrNumber but "<" found.